### PR TITLE
fixes: #365;

### DIFF
--- a/bin/src/generate_output.dart
+++ b/bin/src/generate_output.dart
@@ -43,6 +43,7 @@ extension on Generator {
   Method generateToJsonMethod(dmmf.OutputType output) {
     Expression generateValueExpression(Expression value, dmmf.OutputField field,
         [bool nullable = true]) {
+
       if ((field.outputType.location == dmmf.TypeLocation.scalar &&
               field.outputType.type == 'Json') ||
           field.outputType.location == dmmf.TypeLocation.outputObjectTypes) {
@@ -51,6 +52,18 @@ extension on Generator {
             : value.property('toJson');
 
         return call([]);
+      }
+      else if(field.outputType.location == dmmf.TypeLocation.scalar &&
+              field.outputType.type == 'DateTime') {
+        final call = nullable
+            ? value.nullSafeProperty('toIso8601String')
+            : value.property('toIso8601String');
+        return call([]);
+      }
+      else if(field.outputType.location == dmmf.TypeLocation.enumTypes) {
+        return nullable
+            ? value.nullSafeProperty('name')
+            : value.property('name'); 
       }
 
       return value;


### PR DESCRIPTION
fix: Correct encoding of DateTime and Enum fields in toJson(), ensuring proper JSON response generation
Resolves #365 

## Example
Old Output of Generated Model Class
The old output of the generated toJson() method was as follows:
 ``` 
Map<String, dynamic> toJson() => { 
        'role': role,  
        'created_at': createdAt,
        'updated_at': updatedAt, 
      };
```

### New Output  of Generated Model Class
The toJson() method correctly encodes DateTime fields using toIso8601String() and Enum fields using their string representations.

The expected output of the generated toJson() method is:
```
  Map<String, dynamic> toJson() => { 
        'role': role?.name,  
        'created_at': createdAt?.toIso8601String(),
        'updated_at': updatedAt?.toIso8601String(),        
      };
```

For more info check issue #365 